### PR TITLE
[feat] Support bulk actions for event list view

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
@@ -27,7 +27,6 @@ export const EventWorkingListsViewMenuSetup = ({
         selectionInProgress,
         toggleRowSelected,
         allRowsAreSelected,
-        removeRowsFromSelection,
     } = useSelectedRowsController({ recordIds: dataSource?.map(data => data.id) });
 
     const customListViewMenuContents: CustomMenuContents = useMemo(() => [{
@@ -61,7 +60,6 @@ export const EventWorkingListsViewMenuSetup = ({
             stage={program.stage}
             onClearSelection={clearSelection}
             onUpdateList={onUpdateList}
-            removeRowsFromSelection={removeRowsFromSelection}
         />
     );
 

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingListsCommon/EventBulkActions/hooks/useTrackedEntitiesFromEvents.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingListsCommon/EventBulkActions/hooks/useTrackedEntitiesFromEvents.js
@@ -1,0 +1,31 @@
+import { useDataQuery } from '@dhis2/app-runtime';
+import { useEffect, useState } from 'react';
+
+const buildQuery = {
+    eventsQuery: {
+        resource: 'tracker/events',
+        params: ({ eventIds }) => ({
+            events: eventIds,
+            fields: ['event', 'trackedEntity'],
+        }),
+    },
+};
+
+/**
+ * @param eventIds the list of event ids to get the tracked entities.
+ * @returns the list of tracked entities related to the events without duplicates.
+ */
+export const useTrackedEntitiesFromEvents = () => {
+    const [teis, setTeis] = useState([]);
+    const { data, refetch, loading, error } = useDataQuery(buildQuery, { lazy: true, variables: { eventIds: [] } });
+
+    useEffect(() => {
+        const teiList = data?.eventsQuery?.events
+            ?.map(e => e.trackedEntity)
+            .filter(Boolean) ?? [];
+
+        setTeis(teiList);
+    }, [data]);
+
+    return { teis: [...new Set(teis)], loading, error, refetch };
+};

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/SelectAction/SelectAction.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/SelectAction/SelectAction.js
@@ -20,7 +20,7 @@ import { FormActionModal } from './ FormActionModal';
 
 
 type Props = {
-    selectedRows: { [id: string]: boolean },
+    selectedRows: string[],
     onActionDone: () => void,
     action: TabDeviceAction,
     programId: string,
@@ -90,13 +90,13 @@ export const SelectAction = ({
                             program,
                         ]
                     `.replace(/\s+/g, ''), // eliminamos espacios innecesarios
-                    [filterQueryParam]: Object.keys(selectedRows).join(supportForFeature ? ',' : ';'),
+                    [filterQueryParam]: selectedRows.join(supportForFeature ? ',' : ';'),
                     pageSize: 100,
                 };
             },
         },
         {
-            enabled: Object.keys(selectedRows).length > 0,
+            enabled: selectedRows.length > 0,
             select: (data: any) => {
                 const apiTrackedEntities = handleAPIResponse(REQUESTED_ENTITIES.trackedEntities, data);
                 return apiTrackedEntities;
@@ -255,21 +255,19 @@ export const SelectAction = ({
             setShowLoading(true);
 
             try {
-                const promises = Object.keys(selectedRows)
-                    .filter(teiId => selectedRows[teiId])
-                    .map(async (teiId) => {
-                        const { orgUnit: orgUnitId, enrollments } =
+                const promises = selectedRows.map(async (teiId) => {
+                    const { orgUnit: orgUnitId, enrollments } =
                             trackedEntities?.find(trackedEntity => trackedEntity.trackedEntity === teiId) ?? {};
-                        const enrollmentId = enrollments?.[0]?.enrollment;
+                    const enrollmentId = enrollments?.[0]?.enrollment;
 
-                        if (updateTEA) {
-                            await runUpdateTEA(teiId, orgUnitId);
-                        }
+                    if (updateTEA) {
+                        await runUpdateTEA(teiId, orgUnitId);
+                    }
 
-                        if (smsCommand) {
-                            await runSMSCommand(teiId, orgUnitId, enrollmentId);
-                        }
-                    });
+                    if (smsCommand) {
+                        await runSMSCommand(teiId, orgUnitId, enrollmentId);
+                    }
+                });
 
                 await Promise.all(promises);
                 showSuccessAlert();

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/TrackedEntityBulkActions.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/TrackedEntityBulkActions.component.js
@@ -25,7 +25,7 @@ export const TrackedEntityBulkActionsComponent = ({
     if (!selectedRowsCount) {
         return null;
     }
-
+    const teiList = [...new Set(Object.keys(selectedRows).filter(row => selectedRows[row]))];
 
     return (
         <BulkActionBar
@@ -36,7 +36,7 @@ export const TrackedEntityBulkActionsComponent = ({
             {tabsDeviceActions.map(action => (
                 !isBlackListed(action) ? (
                     <SelectAction
-                        selectedRows={selectedRows}
+                        selectedRows={teiList}
                         programDataWriteAccess={programDataWriteAccess}
                         programId={programId}
                         onActionDone={onUpdateList}

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/TrackedEntityBulkActions.container.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/TrackedEntityBulkActions.container.js
@@ -68,12 +68,27 @@ export const TrackedEntityBulkActions = ({
             log.error(errorCreator('Program stage not found')({ programStageId, stages }));
             throw new Error('Program stage not found');
         }
+        const { removeRowsFromSelection, ...eventBulkProps } = passOnProps;
 
         return (
-            <EventBulkActions
-                stage={stage}
-                {...passOnProps}
-            />
+            <Context.Provider
+                value={{
+                    dataEngine,
+                    sympheosConfig: {
+                        ...sympheosConfig,
+                        isAccountInstance,
+                        instanceType,
+                    // ...FORCE_INSTANCE // To Force instance type. Comment this line for production or if you do not wish to force it
+                    },
+                    onHandleUpdate,
+                }}
+            >
+                <EventBulkActions
+                    stage={stage}
+                    {...eventBulkProps}
+                />
+            </Context.Provider >
+
         );
     }
 
@@ -85,7 +100,7 @@ export const TrackedEntityBulkActions = ({
                     ...sympheosConfig,
                     isAccountInstance,
                     instanceType,
-                    // ...FORCE_INSTANCE // To Force instance type. Comment this line for production or if you do not wish to force it
+                // ...FORCE_INSTANCE // To Force instance type. Comment this line for production or if you do not wish to force it
                 },
                 onHandleUpdate,
             }}


### PR DESCRIPTION
[feat] Support bulk actions for event list view (appears when filteri…ng by program stage)

- TrackedEntityBulkActions now supports the same actions as in TEI view
- Retrieve TEIs associated with the events and remove duplicates before executing actions
- Add new `RequestAction` component for bulk operations
- Integrate `RequestAction` into bulk actions bar

![Screenshot 2025-07-01 at 22 52 08](https://github.com/user-attachments/assets/6eaf0ce5-671f-44d6-9d41-ff15c8a3a203)
![Screenshot 2025-07-01 at 22 52 51](https://github.com/user-attachments/assets/dae4f413-0e24-4099-a049-c9549cdf6158)
